### PR TITLE
Fix duplicate blog URLs and add clean URL routing for SEO

### DIFF
--- a/dev/blog-post.html
+++ b/dev/blog-post.html
@@ -813,6 +813,13 @@
             // Get post slug from URL (supports /blog/slug and ?slug=slug)
             const slug = getSlugFromUrl();
 
+            // Redirect old ?slug= URLs to clean /blog/slug format
+            const querySlug = new URLSearchParams(window.location.search).get('slug');
+            if (querySlug && !window.location.pathname.match(/^\/blog\/[^\/]+/)) {
+                window.location.replace('/blog/' + querySlug);
+                return;
+            }
+
             if (slug) {
                 loadBlogPost(slug);
             } else {

--- a/dev/blog-post.html
+++ b/dev/blog-post.html
@@ -50,7 +50,7 @@
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="ywcRht9p5oOpmSuHT2WXlQ" async></script>
     <link rel="stylesheet" href="css/core.css">
     <link rel="stylesheet" href="css/blog-post.css">
-    <link rel="canonical" href="https://aisle-to-islands.com/blog-post.html">
+    <link rel="canonical" id="canonical-url" href="https://aisle-to-islands.com/blog-post.html">
 
 
     </head>
@@ -314,9 +314,15 @@
         // UTILITY FUNCTIONS
         // ==========================================
 
-        function getUrlParameter(name) {
+        function getSlugFromUrl() {
+            // First try clean URL path: /blog/my-post-slug
+            const pathMatch = window.location.pathname.match(/^\/blog\/([^\/]+)\/?$/);
+            if (pathMatch) {
+                return pathMatch[1];
+            }
+            // Fallback to query parameter: ?slug=my-post-slug
             const urlParams = new URLSearchParams(window.location.search);
-            return urlParams.get(name);
+            return urlParams.get('slug');
         }
 
         function formatDate(dateString) {
@@ -334,7 +340,9 @@
             const title = `${seoTitle} | Aisle to Islands`;
             const description = post.seo?.metaDescription || post.excerpt;
             const socialImage = post.seo?.ogImage?.asset?.url || post.mainImage?.asset?.url || '/tailored_experience_logo.png';
-            const currentUrl = window.location.href;
+            const slug = post.slug?.current || '';
+            const canonicalUrl = slug ? `https://aisle-to-islands.com/blog/${slug}` : window.location.href;
+            const currentUrl = canonicalUrl;
 
             // Update title and description
             document.getElementById('page-title').textContent = title;
@@ -350,6 +358,9 @@
             document.getElementById('twitter-title').setAttribute('content', title);
             document.getElementById('twitter-description').setAttribute('content', description);
             document.getElementById('twitter-image').setAttribute('content', socialImage);
+
+            // Update canonical URL to the clean blog URL
+            document.getElementById('canonical-url').setAttribute('href', canonicalUrl);
 
             // Add keywords meta tag if available
             if (post.seo?.keywords && post.seo.keywords.length > 0) {
@@ -374,7 +385,7 @@
             }
 
             return posts.map(post => `
-                <a href="blog-post.html?slug=${post.slug}" class="related-post-card fade-in-element">
+                <a href="/blog/${post.slug}" class="related-post-card fade-in-element">
                     <div class="related-post-image" style="background-image: url('${post.image}')"></div>
                     <div class="related-post-content">
                         <h3 class="related-post-title">${post.title}</h3>
@@ -799,8 +810,8 @@
 
             initMobileMenu();
 
-            // Get post slug from URL
-            const slug = getUrlParameter('slug');
+            // Get post slug from URL (supports /blog/slug and ?slug=slug)
+            const slug = getSlugFromUrl();
 
             if (slug) {
                 loadBlogPost(slug);

--- a/dev/js/blog.js
+++ b/dev/js/blog.js
@@ -454,7 +454,7 @@ class BlogManager {
         const imageUrl = post.mainImage?.asset?.url || '/images/blog/default-post-image.jpg';
         const categoryTitle = post.category?.title || 'General';
         const formattedDate = this.formatDate(post.publishedAt);
-        const postUrl = `blog-post.html?slug=${post.slug.current}`;
+        const postUrl = `/blog/${post.slug.current}`;
 
         if (featured) {
             // Build meta content for featured posts

--- a/dist/_redirects
+++ b/dist/_redirects
@@ -5,6 +5,9 @@
 /inquire                   /inquire.html                    301
 /blog                      /blog.html                       301
 
+# Clean blog post URLs (rewrite so /blog/post-slug serves blog-post.html)
+/blog/:slug                /blog-post.html                  200
+
 # Legacy URL redirects (old website structure)
 /destination-wedding-planning.html  /destination-wedding.html  301
 /luxury-honeymoon-planning.html     /curated-honeymoon.html    301

--- a/dist/blog-post.html
+++ b/dist/blog-post.html
@@ -813,6 +813,13 @@
             // Get post slug from URL (supports /blog/slug and ?slug=slug)
             const slug = getSlugFromUrl();
 
+            // Redirect old ?slug= URLs to clean /blog/slug format
+            const querySlug = new URLSearchParams(window.location.search).get('slug');
+            if (querySlug && !window.location.pathname.match(/^\/blog\/[^\/]+/)) {
+                window.location.replace('/blog/' + querySlug);
+                return;
+            }
+
             if (slug) {
                 loadBlogPost(slug);
             } else {

--- a/dist/blog-post.html
+++ b/dist/blog-post.html
@@ -50,7 +50,7 @@
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="ywcRht9p5oOpmSuHT2WXlQ" async></script>
     <link rel="stylesheet" href="css/core.css">
     <link rel="stylesheet" href="css/blog-post.css">
-    <link rel="canonical" href="https://aisle-to-islands.com/blog-post.html">
+    <link rel="canonical" id="canonical-url" href="https://aisle-to-islands.com/blog-post.html">
 
 
     </head>
@@ -314,9 +314,15 @@
         // UTILITY FUNCTIONS
         // ==========================================
 
-        function getUrlParameter(name) {
+        function getSlugFromUrl() {
+            // First try clean URL path: /blog/my-post-slug
+            const pathMatch = window.location.pathname.match(/^\/blog\/([^\/]+)\/?$/);
+            if (pathMatch) {
+                return pathMatch[1];
+            }
+            // Fallback to query parameter: ?slug=my-post-slug
             const urlParams = new URLSearchParams(window.location.search);
-            return urlParams.get(name);
+            return urlParams.get('slug');
         }
 
         function formatDate(dateString) {
@@ -334,7 +340,9 @@
             const title = `${seoTitle} | Aisle to Islands`;
             const description = post.seo?.metaDescription || post.excerpt;
             const socialImage = post.seo?.ogImage?.asset?.url || post.mainImage?.asset?.url || '/tailored_experience_logo.png';
-            const currentUrl = window.location.href;
+            const slug = post.slug?.current || '';
+            const canonicalUrl = slug ? `https://aisle-to-islands.com/blog/${slug}` : window.location.href;
+            const currentUrl = canonicalUrl;
 
             // Update title and description
             document.getElementById('page-title').textContent = title;
@@ -350,6 +358,9 @@
             document.getElementById('twitter-title').setAttribute('content', title);
             document.getElementById('twitter-description').setAttribute('content', description);
             document.getElementById('twitter-image').setAttribute('content', socialImage);
+
+            // Update canonical URL to the clean blog URL
+            document.getElementById('canonical-url').setAttribute('href', canonicalUrl);
 
             // Add keywords meta tag if available
             if (post.seo?.keywords && post.seo.keywords.length > 0) {
@@ -374,7 +385,7 @@
             }
 
             return posts.map(post => `
-                <a href="blog-post.html?slug=${post.slug}" class="related-post-card fade-in-element">
+                <a href="/blog/${post.slug}" class="related-post-card fade-in-element">
                     <div class="related-post-image" style="background-image: url('${post.image}')"></div>
                     <div class="related-post-content">
                         <h3 class="related-post-title">${post.title}</h3>
@@ -799,8 +810,8 @@
 
             initMobileMenu();
 
-            // Get post slug from URL
-            const slug = getUrlParameter('slug');
+            // Get post slug from URL (supports /blog/slug and ?slug=slug)
+            const slug = getSlugFromUrl();
 
             if (slug) {
                 loadBlogPost(slug);

--- a/dist/js/blog.js
+++ b/dist/js/blog.js
@@ -454,7 +454,7 @@ class BlogManager {
         const imageUrl = post.mainImage?.asset?.url || '/images/blog/default-post-image.jpg';
         const categoryTitle = post.category?.title || 'General';
         const formattedDate = this.formatDate(post.publishedAt);
-        const postUrl = `blog-post.html?slug=${post.slug.current}`;
+        const postUrl = `/blog/${post.slug.current}`;
 
         if (featured) {
             // Build meta content for featured posts


### PR DESCRIPTION
All blog posts shared the same canonical URL (blog-post.html) causing
Google to treat them as duplicate content. This adds Netlify rewrite
rules for clean URLs (/blog/post-slug), dynamically sets canonical
tags per post, and updates all internal links to use the new format.

https://claude.ai/code/session_01AGy2F7JnaKPhzdv2VezRdQ