### PR TITLE
Fix broken styles on clean blog URLs by using absolute paths

### DIFF
--- a/dev/blog-post.html
+++ b/dev/blog-post.html
@@ -48,8 +48,8 @@
 
 
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="ywcRht9p5oOpmSuHT2WXlQ" async></script>
-    <link rel="stylesheet" href="css/core.css">
-    <link rel="stylesheet" href="css/blog-post.css">
+    <link rel="stylesheet" href="/css/core.css">
+    <link rel="stylesheet" href="/css/blog-post.css">
     <link rel="canonical" id="canonical-url" href="https://aisle-to-islands.com/blog-post.html">
 
 
@@ -66,14 +66,14 @@
                 </div>
 
                 <ul class="nav-links" role="menubar">
-                    <li role="none"><a href="index.html" role="menuitem">Home</a></li>
-                    <li role="none"><a href="destination-wedding.html" role="menuitem">Destination Wedding</a></li>
-                    <li role="none"><a href="curated-honeymoon.html" role="menuitem">Curated Honeymoon</a></li>
+                    <li role="none"><a href="/index.html" role="menuitem">Home</a></li>
+                    <li role="none"><a href="/destination-wedding.html" role="menuitem">Destination Wedding</a></li>
+                    <li role="none"><a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a></li>
                     <li role="none"><a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a></li>
-                    <li role="none"><a href="meet-your-planner.html" role="menuitem">Meet Your Planner</a></li>
+                    <li role="none"><a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a></li>
                     <!-- <li role="none"><a href="packages.html" role="menuitem">Packages</a></li> -->
-                    <li role="none"><a href="blog.html" role="menuitem" aria-current="page">Blog</a></li>
-                    <li role="none"><a href="inquire.html" role="menuitem">Inquire</a></li>
+                    <li role="none"><a href="/blog.html" role="menuitem" aria-current="page">Blog</a></li>
+                    <li role="none"><a href="/inquire.html" role="menuitem">Inquire</a></li>
                 </ul>
 
 
@@ -85,14 +85,14 @@
             </div>
 
             <div class="mobile-nav" role="menu">
-                <a href="index.html" role="menuitem">Home</a>
-                <a href="destination-wedding.html" role="menuitem">Destination Wedding</a>
-                <a href="curated-honeymoon.html" role="menuitem">Curated Honeymoon</a>
+                <a href="/index.html" role="menuitem">Home</a>
+                <a href="/destination-wedding.html" role="menuitem">Destination Wedding</a>
+                <a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a>
                 <a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a>
-                <a href="meet-your-planner.html" role="menuitem">Meet Your Planner</a>
+                <a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a>
                 <!-- <a href="packages.html" role="menuitem">Packages</a> -->
-                <a href="blog.html" role="menuitem" aria-current="page">Blog</a>
-                <a href="inquire.html" role="menuitem">Inquire</a>
+                <a href="/blog.html" role="menuitem" aria-current="page">Blog</a>
+                <a href="/inquire.html" role="menuitem">Inquire</a>
             </div>
         </nav>
 
@@ -116,19 +116,19 @@
             <div class="footer-section">
                 <h4>Services</h4>
                 <ul>
-                    <li><a href="destination-wedding.html">Destination Wedding Planning</a></li>
-                    <li><a href="curated-honeymoon.html">Curated Honeymoon Planning</a></li>
+                    <li><a href="/destination-wedding.html">Destination Wedding Planning</a></li>
+                    <li><a href="/curated-honeymoon.html">Curated Honeymoon Planning</a></li>
                     <!-- <li><a href="packages.html">Packages</a></li> -->
-                    <li><a href="inquire.html">Inquire</a></li>
+                    <li><a href="/inquire.html">Inquire</a></li>
                 </ul>
             </div>
 
             <div class="footer-section">
                 <h4>Company</h4>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="inquire.html">Inquire</a></li>
-                    <li><a href="privacy.html">Privacy Policy</a></li>
+                    <li><a href="/index.html">Home</a></li>
+                    <li><a href="/inquire.html">Inquire</a></li>
+                    <li><a href="/privacy.html">Privacy Policy</a></li>
 <!--                    <li><a href="terms-of-service.html">Terms of Service</a></li>-->
                 </ul>
             </div>
@@ -530,7 +530,7 @@
                 <article class="article-header">
                     <div class="article-header-container">
                         <nav class="breadcrumb">
-                            <a href="index.html">Home</a> / <a href="blog.html">Blog</a> / <span>${post.title}</span>
+                            <a href="/index.html">Home</a> / <a href="/blog.html">Blog</a> / <span>${post.title}</span>
                         </nav>
 
                         <div class="hero-animate">
@@ -703,7 +703,7 @@
                     <div class="error-state">
                         <h2>Post Not Found</h2>
                         <p>The blog post you're looking for doesn't exist or has been moved.</p>
-                        <a href="blog.html">← Back to Blog</a>
+                        <a href="/blog.html">← Back to Blog</a>
                     </div>
                 `;
             }

--- a/dist/blog-post.html
+++ b/dist/blog-post.html
@@ -48,8 +48,8 @@
 
 
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="ywcRht9p5oOpmSuHT2WXlQ" async></script>
-    <link rel="stylesheet" href="css/core.css">
-    <link rel="stylesheet" href="css/blog-post.css">
+    <link rel="stylesheet" href="/css/core.css">
+    <link rel="stylesheet" href="/css/blog-post.css">
     <link rel="canonical" id="canonical-url" href="https://aisle-to-islands.com/blog-post.html">
 
 
@@ -66,14 +66,14 @@
                 </div>
 
                 <ul class="nav-links" role="menubar">
-                    <li role="none"><a href="index.html" role="menuitem">Home</a></li>
-                    <li role="none"><a href="destination-wedding.html" role="menuitem">Destination Wedding</a></li>
-                    <li role="none"><a href="curated-honeymoon.html" role="menuitem">Curated Honeymoon</a></li>
+                    <li role="none"><a href="/index.html" role="menuitem">Home</a></li>
+                    <li role="none"><a href="/destination-wedding.html" role="menuitem">Destination Wedding</a></li>
+                    <li role="none"><a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a></li>
                     <li role="none"><a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a></li>
-                    <li role="none"><a href="meet-your-planner.html" role="menuitem">Meet Your Planner</a></li>
+                    <li role="none"><a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a></li>
                     <!-- <li role="none"><a href="packages.html" role="menuitem">Packages</a></li> -->
-                    <li role="none"><a href="blog.html" role="menuitem" aria-current="page">Blog</a></li>
-                    <li role="none"><a href="inquire.html" role="menuitem">Inquire</a></li>
+                    <li role="none"><a href="/blog.html" role="menuitem" aria-current="page">Blog</a></li>
+                    <li role="none"><a href="/inquire.html" role="menuitem">Inquire</a></li>
                 </ul>
 
 
@@ -85,14 +85,14 @@
             </div>
 
             <div class="mobile-nav" role="menu">
-                <a href="index.html" role="menuitem">Home</a>
-                <a href="destination-wedding.html" role="menuitem">Destination Wedding</a>
-                <a href="curated-honeymoon.html" role="menuitem">Curated Honeymoon</a>
+                <a href="/index.html" role="menuitem">Home</a>
+                <a href="/destination-wedding.html" role="menuitem">Destination Wedding</a>
+                <a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a>
                 <a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a>
-                <a href="meet-your-planner.html" role="menuitem">Meet Your Planner</a>
+                <a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a>
                 <!-- <a href="packages.html" role="menuitem">Packages</a> -->
-                <a href="blog.html" role="menuitem" aria-current="page">Blog</a>
-                <a href="inquire.html" role="menuitem">Inquire</a>
+                <a href="/blog.html" role="menuitem" aria-current="page">Blog</a>
+                <a href="/inquire.html" role="menuitem">Inquire</a>
             </div>
         </nav>
 
@@ -116,19 +116,19 @@
             <div class="footer-section">
                 <h4>Services</h4>
                 <ul>
-                    <li><a href="destination-wedding.html">Destination Wedding Planning</a></li>
-                    <li><a href="curated-honeymoon.html">Curated Honeymoon Planning</a></li>
+                    <li><a href="/destination-wedding.html">Destination Wedding Planning</a></li>
+                    <li><a href="/curated-honeymoon.html">Curated Honeymoon Planning</a></li>
                     <!-- <li><a href="packages.html">Packages</a></li> -->
-                    <li><a href="inquire.html">Inquire</a></li>
+                    <li><a href="/inquire.html">Inquire</a></li>
                 </ul>
             </div>
 
             <div class="footer-section">
                 <h4>Company</h4>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="inquire.html">Inquire</a></li>
-                    <li><a href="privacy.html">Privacy Policy</a></li>
+                    <li><a href="/index.html">Home</a></li>
+                    <li><a href="/inquire.html">Inquire</a></li>
+                    <li><a href="/privacy.html">Privacy Policy</a></li>
 <!--                    <li><a href="terms-of-service.html">Terms of Service</a></li>-->
                 </ul>
             </div>
@@ -530,7 +530,7 @@
                 <article class="article-header">
                     <div class="article-header-container">
                         <nav class="breadcrumb">
-                            <a href="index.html">Home</a> / <a href="blog.html">Blog</a> / <span>${post.title}</span>
+                            <a href="/index.html">Home</a> / <a href="/blog.html">Blog</a> / <span>${post.title}</span>
                         </nav>
 
                         <div class="hero-animate">
@@ -703,7 +703,7 @@
                     <div class="error-state">
                         <h2>Post Not Found</h2>
                         <p>The blog post you're looking for doesn't exist or has been moved.</p>
-                        <a href="blog.html">← Back to Blog</a>
+                        <a href="/blog.html">← Back to Blog</a>
                     </div>
                 `;
             }


### PR DESCRIPTION
When blog posts are served at /blog/slug via Netlify rewrite, relative paths like css/core.css resolved to /blog/css/core.css (404). Changed all CSS and internal link hrefs to absolute paths (starting with /) so they resolve correctly regardless of URL depth.

https://claude.ai/code/session_01AGy2F7JnaKPhzdv2VezRdQ