### PR TITLE
Fix Netlify build: set base to repo root to avoid dist/dist publish path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  base = "/"
   publish = "dist"
   command = "npm install && npm run build"
 


### PR DESCRIPTION
The Netlify site UI had base set to dist/, causing the toml's publish = "dist" to resolve to dist/dist. Setting base = "/" in the toml overrides this so the build runs from the repo root where package.json and build-blog.js live.

https://claude.ai/code/session_01G9VQw5s9mGmFhDVgXZH9p1