### PR TITLE
Standardize blog URLs to trailing slash format

### DIFF
--- a/build-blog.js
+++ b/build-blog.js
@@ -253,7 +253,7 @@ const NAV_HTML = `
                 <li role="none"><a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a></li>
                 <li role="none"><a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a></li>
                 <li role="none"><a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a></li>
-                <li role="none"><a href="/blog.html" role="menuitem" aria-current="page">Blog</a></li>
+                <li role="none"><a href="/blog/" role="menuitem" aria-current="page">Blog</a></li>
                 <li role="none"><a href="/inquire.html" role="menuitem">Inquire</a></li>
             </ul>
 
@@ -270,7 +270,7 @@ const NAV_HTML = `
             <a href="/curated-honeymoon.html" role="menuitem">Curated Honeymoon</a>
             <a href="https://legacy.aisle-to-islands.com" role="menuitem">Legacy Blueprint</a>
             <a href="/meet-your-planner.html" role="menuitem">Meet Your Planner</a>
-            <a href="/blog.html" role="menuitem" aria-current="page">Blog</a>
+            <a href="/blog/" role="menuitem" aria-current="page">Blog</a>
             <a href="/inquire.html" role="menuitem">Inquire</a>
         </div>
     </nav>`;
@@ -488,7 +488,7 @@ ${NAV_HTML}
         <article class="article-header">
             <div class="article-header-container">
                 <nav class="breadcrumb">
-                    <a href="/index.html">Home</a> / <a href="/blog.html">Blog</a> / <span>${escapeHtml(post.title)}</span>
+                    <a href="/index.html">Home</a> / <a href="/blog/">Blog</a> / <span>${escapeHtml(post.title)}</span>
                 </nav>
 
                 <div class="hero-animate">
@@ -606,7 +606,7 @@ function generateBlogListingHtml(posts) {
     '@type': 'Blog',
     name: 'Aisle to Islands Blog',
     description: 'Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips.',
-    url: `${SITE_URL}/blog`,
+    url: `${SITE_URL}/blog/`,
     publisher: {
       '@type': 'Organization',
       name: 'Aisle to Islands',
@@ -622,11 +622,25 @@ function generateBlogListingHtml(posts) {
     <title>Travel Insights & Wedding Planning Tips | Aisle to Islands</title>
     <meta name="description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
 
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="${SITE_URL}/blog/">
+    <meta property="og:title" content="Travel Insights &amp; Wedding Planning Tips | Aisle to Islands">
+    <meta property="og:description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
+    <meta property="og:image" content="${SITE_URL}/images/logos/tailored_experience_logo.jpg">
+    <meta property="og:site_name" content="Aisle to Islands">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Travel Insights &amp; Wedding Planning Tips | Aisle to Islands">
+    <meta name="twitter:description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
+    <meta name="twitter:image" content="${SITE_URL}/images/logos/tailored_experience_logo.jpg">
+
     ${GA_SCRIPT}
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="ywcRht9p5oOpmSuHT2WXlQ" async></script>
     <link rel="stylesheet" href="/css/core.css">
     <link rel="stylesheet" href="/css/blog.css">
-    <link rel="canonical" href="${SITE_URL}/blog">
+    <link rel="canonical" href="${SITE_URL}/blog/">
 
     <script type="application/ld+json">${schemaJson}</script>
 </head>
@@ -692,7 +706,7 @@ ${FOOTER_HTML}
 function generateSitemap(posts) {
   const staticPages = [
     '',
-    '/blog',
+    '/blog/',
     '/destination-wedding.html',
     '/curated-honeymoon.html',
     '/meet-your-planner.html',
@@ -703,14 +717,14 @@ function generateSitemap(posts) {
   const urls = staticPages.map(page => `
   <url>
     <loc>${SITE_URL}${page}</loc>
-    <changefreq>${page === '/blog' ? 'daily' : 'monthly'}</changefreq>
-    <priority>${page === '' ? '1.0' : page === '/blog' ? '0.9' : '0.7'}</priority>
+    <changefreq>${page === '/blog/' ? 'daily' : 'monthly'}</changefreq>
+    <priority>${page === '' ? '1.0' : page === '/blog/' ? '0.9' : '0.7'}</priority>
   </url>`);
 
   for (const post of posts) {
     urls.push(`
   <url>
-    <loc>${SITE_URL}/blog/${post.slug.current}</loc>
+    <loc>${SITE_URL}/blog/${post.slug.current}/</loc>
     <lastmod>${post.publishedAt ? new Date(post.publishedAt).toISOString().split('T')[0] : new Date().toISOString().split('T')[0]}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/dist/_redirects
+++ b/dist/_redirects
@@ -4,7 +4,10 @@
 /curated-honeymoon         /curated-honeymoon.html          301
 /inquire                   /inquire.html                    301
 
-# Blog listing - served by static dist/blog/index.html (built by SSG)
+# Blog listing - canonical URL is /blog/ (served from dist/blog/index.html built by SSG)
+# Redirect old blog.html to canonical /blog/ (forced to override existing file)
+/blog.html                 /blog/                           301!
+
 # Individual posts served from dist/blog/{slug}/index.html (built by SSG)
 # Fallback: if a post wasn't generated, rewrite to client-side renderer
 /blog/:slug                /blog-post.html                  200

--- a/dist/blog.html
+++ b/dist/blog.html
@@ -6,10 +6,24 @@
     <title>Travel Insights & Wedding Planning Tips | Aisle to Islands</title>
     <meta name="description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
 
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aisle-to-islands.com/blog/">
+    <meta property="og:title" content="Travel Insights &amp; Wedding Planning Tips | Aisle to Islands">
+    <meta property="og:description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
+    <meta property="og:image" content="https://aisle-to-islands.com/images/logos/tailored_experience_logo.jpg">
+    <meta property="og:site_name" content="Aisle to Islands">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Travel Insights &amp; Wedding Planning Tips | Aisle to Islands">
+    <meta name="twitter:description" content="Expert insights on destination wedding planning, luxury honeymoon destinations, and travel tips from Aisle to Islands.">
+    <meta name="twitter:image" content="https://aisle-to-islands.com/images/logos/tailored_experience_logo.jpg">
+
     <script src="https://analytics.ahrefs.com/analytics.js" data-key="6HTmP9C8+jW0NY/7x8/a7g" async></script>
     <link rel="stylesheet" href="css/core.css">
     <link rel="stylesheet" href="css/blog.css">
-    <link rel="canonical" href="https://aisle-to-islands.com/blog.html">
+    <link rel="canonical" href="https://aisle-to-islands.com/blog/">
 </head>
 <body>
     <nav role="navigation" aria-label="Main navigation" class="header-sticky">

--- a/dist/index.html
+++ b/dist/index.html
@@ -14,6 +14,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Aisle to Islands">
 
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Luxury Destination Wedding &amp; Honeymoon Planning">
+    <meta name="twitter:description" content="Expert planning transforms your romantic vision into reality. Destination weddings &amp; curated honeymoons for discerning couples.">
+    <meta name="twitter:image" content="https://aisle-to-islands.com/images/logos/tailored_experience_logo.jpg">
+
     <!-- Preload critical CSS -->
     <link rel="preload" href="css/core.css" as="style">
     <link rel="preload" href="css/homepage.css" as="style">


### PR DESCRIPTION
## Summary
This PR standardizes all blog-related URLs to use trailing slashes (`/blog/` instead of `/blog.html`), improving URL consistency and SEO best practices. It also adds Open Graph and Twitter Card meta tags to enhance social media sharing.

## Key Changes
- **URL Standardization**: Updated all blog navigation links and references from `/blog.html` to `/blog/` across navigation menus, breadcrumbs, and schema markup
- **Meta Tags**: Added Open Graph and Twitter Card meta tags to the blog listing page for improved social media preview cards
- **Canonical URLs**: Updated canonical link tags to use the trailing slash format (`/blog/`)
- **Sitemap Updates**: Modified sitemap generation to use `/blog/` and `/blog/{slug}/` with trailing slashes for consistency
- **Redirect Rule**: Added a 301 redirect from `/blog.html` to `/blog/` in the `_redirects` file to maintain backward compatibility
- **Homepage Enhancement**: Added Twitter Card meta tags to the homepage for consistent social sharing metadata

## Implementation Details
- The changes maintain backward compatibility through a forced redirect rule (`301!`) that overrides any existing `/blog.html` file
- Schema.org JSON-LD markup for the blog is updated to reflect the new URL structure
- All internal links pointing to the blog have been updated to use the new trailing slash format
- The sitemap correctly identifies `/blog/` as a daily-updated page with 0.9 priority, while individual posts maintain weekly updates with 0.8 priority

https://claude.ai/code/session_01UF29z7W5PW8puFK6VDGpsa